### PR TITLE
[#4] Update URL validation to support Next Gen Trigger Webhooks

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -5,8 +5,12 @@ function convertURL() {
         input = urlBox.placeholder
     }
 
-    // check for valid slack url input
-    const regex = /hooks.slack.com\/workflows/g;
+    // validate the slack url:
+    // 1. hooks.slack.com/workflows/... - Workflow Builder 1.0 Webhooks
+    // 2. hooks.slack.com/triggers/.... - Next Generation Webhook Triggers
+    //
+    // regex playground: https://rubular.com/r/7Ml72BmnaYQCxk
+    const regex = /hooks.slack.com\/(workflows|triggers)/g;
     const valid = input.match(regex)
     console.log(valid)
 

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ app.use(sslRedirect());
 app.use(express.static('public'))
 
 
-app.post('/workflows/*', (req, res) => {
+app.post(['/workflows/*', '/triggers/*'], (req, res) => {
     res.send('ok');
     const payload = req.body;
     const flatPayload = flatten(payload);
@@ -43,7 +43,7 @@ app.post('/workflows/*', (req, res) => {
 })
 
 app.get('/', (req, res) => {
-    // this route should ask you to post your slack webhook urls and give you the webhook to supply to github 
+    // this route should ask you to post your slack webhook urls and give you the webhook to supply to github
     // (Essentially changes hooks.slack.com to our servers path)
     res.sendFile(path.join(__dirname+'/public/index.html'));
     console.log(req);


### PR DESCRIPTION
### Summary

Fixes #4 by updating the client-side regex URL validation to support both the Workflow Builder 1.0 Webhook URLs and Next Generation Platform Trigger Webhook URLs:
1. `https://hooks.slack.com/workflows/...`
2. `https://hooks.slack.com/triggers/....`

### Test steps

```bash
$ npm start

# Open browser to http://localhost:3000
# Confirm URL succeeds: https://hooks.slack.com/workflows/ABC123
# Confirm URL succeeds: https://hooks.slack.com/triggers/ABC123
# Confirm URL fails: https://hooks.slack.com/invalid/url

# Test a route for /workflows/ABC123
# Or, use a curl statement:
$ curl -i -X POST -H "Content-Type: application/json" -d "{\"key\":\"val\"}" http://localhost:3000/workflows/ABC123

# Test a route for /triggers/ABC123
# Or, use a curl statement:
$ curl -i -X POST -H "Content-Type: application/json" -d "{\"key\":\"val\"}" http://localhost:3000/triggers/ABC123
```