### PR TITLE
text/plain header compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,13 @@ app.use(bodyParser.urlencoded({
     extended: true
 }));
 
-app.use(bodyParser.json());
+app.use(express.json({
+    type: [
+        'application/json',
+        'text/plain'
+    ]
+}));
+
 app.use(sslRedirect());
 // Redirect http calls to https
 // comment this out if you aren't using SSL


### PR DESCRIPTION
Add compatibility for AWS SNS (and other services that send the text/plain header instead of application/json).

Originally, when receiving a hook request from SNS, because it sends text/plain in the header, pancake-studio only receives a `{}` from the body. This is because of the built in json parsing. Instead, we tell express to allow the text/plain header, and as long as the body is json, it will be properly parsed.