### PR TITLE
fix: Change delimeter for flatten to underscore

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,8 +37,13 @@ app.use(express.static('public'))
 app.post(['/workflows/*', '/triggers/*'], (req, res) => {
     res.send('ok');
     const payload = req.body;
-    // Slack restricts variable keys to "a combination of letters, numbers, hyphens, and underscores."
-    const flatPayload = flatten(payload, { delimiter: '_' });
+     // Slack's new Workflow builder restricts variable keys to
+    // "a combination of letters, numbers, hyphens, and underscores."
+    //
+    // Maintain backwards compatibility with legacy workflow builder
+    // where a '.' is supported to delimit flattened payloads
+    const delimiter = req.path.includes('/triggers/') ? '_' : '.';
+    const flatPayload = flatten(payload, { delimiter: delimiter });
 
     // workflow builder requires values to be strings
     // iterate over every value and convert it to string

--- a/server.js
+++ b/server.js
@@ -37,7 +37,8 @@ app.use(express.static('public'))
 app.post(['/workflows/*', '/triggers/*'], (req, res) => {
     res.send('ok');
     const payload = req.body;
-    const flatPayload = flatten(payload);
+    // Slack restricts variable keys to "a combination of letters, numbers, hyphens, and underscores."
+    const flatPayload = flatten(payload, { delimiter: '_' });
 
     // workflow builder requires values to be strings
     // iterate over every value and convert it to string


### PR DESCRIPTION
Updated invocation of `flatten` to define options for changing delimeter from the default `.` to an underscore `_` to appease Slack's requirements for variable keys to "only contain a combination of letters, numbers, hyphens, and underscores." #9 

![image](https://github.com/stevengill/pancake-studio/assets/1593912/4f026486-a1da-476a-9b7b-a9cf87912b9c)